### PR TITLE
feat: Add suspend/resume functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ mod painting;
 pub use painting::{Painter, StyledText};
 
 mod engine;
-pub use engine::Reedline;
+pub use engine::{Reedline, SuspendGuard};
 
 mod result;
 pub use result::{ReedlineError, ReedlineErrorVariants, Result};


### PR DESCRIPTION
## Summary
Adds minimal suspend/resume functionality to reedline for better process control.

## Changes
- Added suspend() and resume() methods to Engine
- Implemented proper terminal state management during suspend/resume
- Maintains cursor position and input state across suspend cycles